### PR TITLE
Implement fake DaData address suggestion server

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,33 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/dadatamock:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY server.js ./
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
 # dadatamock
 
-мокаем дадату
+Мокаем сервис DaData для нагрузочного тестирования.
+Каждый запрос обрабатывается ровно за 200&nbsp;мс независимо от нагрузки.
+
+## Запуск
+
+```bash
+node server.js
+```
+
+Сервис слушает порт `3000` по умолчанию и предоставляет единственный эндпоинт:
+
+```
+POST /suggestions/api/4_1/rs/suggest/address
+```
+
+Пример запроса:
+
+```bash
+curl -X POST http://localhost:3000/suggestions/api/4_1/rs/suggest/address \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "Москва"}'
+```
+
+## Docker
+
+Сервис можно запустить в контейнере:
+
+```bash
+docker build -t dadatamock .
+docker run -p 3000:3000 dadatamock
+```
+
+В репозитории присутствует workflow GitHub Actions, который собирает и
+публикует образ в Docker Hub. Для работы workflow необходимо задать секреты
+`DOCKERHUB_USERNAME` и `DOCKERHUB_TOKEN` в настройках репозитория.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dadatamock",
+  "version": "1.0.0",
+  "description": "мокаем дадату",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,61 @@
+const http = require('http');
+
+const PORT = process.env.PORT || 3000;
+
+function parseBody(req, callback) {
+  let body = '';
+  req.on('data', chunk => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    try {
+      const data = JSON.parse(body || '{}');
+      callback(null, data);
+    } catch (err) {
+      callback(err);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const start = Date.now();
+
+  const sendResponse = (statusCode, payload) => {
+    const elapsed = Date.now() - start;
+    const delay = Math.max(0, 200 - elapsed);
+    setTimeout(() => {
+      res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(payload));
+    }, delay);
+  };
+
+  if (req.method === 'POST' && req.url === '/suggestions/api/4_1/rs/suggest/address') {
+    parseBody(req, (err, data) => {
+      if (err) {
+        sendResponse(400, { error: 'Invalid JSON' });
+        return;
+      }
+
+      const query = data.query || '';
+      const suggestions = [];
+      for (let i = 1; i <= 5; i++) {
+        suggestions.push({
+          value: `${query} fake address ${i}`,
+          unrestricted_value: `${query} fake address ${i}`,
+          data: {
+            from_bound: data.from_bound ? data.from_bound.value : null,
+            to_bound: data.to_bound ? data.to_bound.value : null
+          }
+        });
+      }
+
+      sendResponse(200, { suggestions });
+    });
+  } else {
+    sendResponse(404, { error: 'Not found' });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Fake Dadata server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create simple HTTP server using Node core modules
- document how to start server
- ensure each request finishes after 200ms
- add Dockerfile and GitHub Actions workflow to build/push image

## Testing
- `node server.js & sleep 1 && kill $!`
- `node server.js & PID=$!; sleep 1; curl -s -w '%{time_total}\n' -o /dev/null -X POST http://localhost:3000/suggestions/api/4_1/rs/suggest/address -H 'Content-Type: application/json' -d '{"query":"test"}'; kill $PID`

------
https://chatgpt.com/codex/tasks/task_e_685e11fc6598832a93993d5c003def08