### PR TITLE
Add metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ node server.js
 POST /suggestions/api/4_1/rs/suggest/address
 ```
 
+Дополнительно доступен эндпоинт для экспорта метрик в формате Prometheus:
+
+```
+GET /metrics
+```
+
 Пример запроса:
 
 ```bash

--- a/metrics.js
+++ b/metrics.js
@@ -1,0 +1,30 @@
+const metrics = {
+  requestCounter: 0,
+  totalDuration: 0,
+  errorCounter: 0
+};
+
+function recordRequest(statusCode, duration) {
+  metrics.requestCounter += 1;
+  metrics.totalDuration += duration;
+  if (statusCode >= 400) {
+    metrics.errorCounter += 1;
+  }
+}
+
+function getMetrics() {
+  const avgDuration = metrics.requestCounter ? metrics.totalDuration / metrics.requestCounter : 0;
+  return [
+    '# HELP http_requests_total Total HTTP requests',
+    '# TYPE http_requests_total counter',
+    `http_requests_total ${metrics.requestCounter}`,
+    '# HELP http_requests_errors_total Total HTTP error responses',
+    '# TYPE http_requests_errors_total counter',
+    `http_requests_errors_total ${metrics.errorCounter}`,
+    '# HELP http_request_duration_ms_avg Average request duration in milliseconds',
+    '# TYPE http_request_duration_ms_avg gauge',
+    `http_request_duration_ms_avg ${avgDuration}`
+  ].join('\n');
+}
+
+module.exports = { recordRequest, getMetrics };

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const http = require('http');
+const { recordRequest, getMetrics } = require('./metrics');
 
 const PORT = process.env.PORT || 3000;
 
@@ -121,12 +122,20 @@ function parseBody(req, callback) {
 const server = http.createServer((req, res) => {
   const start = Date.now();
 
+  if (req.method === 'GET' && req.url === '/metrics') {
+    res.writeHead(200, { 'Content-Type': 'text/plain; version=0.0.4' });
+    res.end(getMetrics());
+    recordRequest(200, Date.now() - start);
+    return;
+  }
+
   const sendResponse = (statusCode, payload) => {
     const elapsed = Date.now() - start;
     const delay = Math.max(0, 200 - elapsed);
     setTimeout(() => {
       res.writeHead(statusCode, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(payload));
+      recordRequest(statusCode, Date.now() - start);
     }, delay);
   };
 


### PR DESCRIPTION
## Summary
- capture stats about incoming requests
- expose request metrics on `/metrics`
- document metrics endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6871647a43a0832a9493c29a402b4b18