### PR TITLE
Fix missing metrics module in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install --production
 COPY server.js ./
+COPY metrics.js ./
 EXPOSE 3000
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
- copy `metrics.js` into the Docker image so the server can `require('./metrics')`

## Testing
- `docker build -t dadatamock .`

------
https://chatgpt.com/codex/tasks/task_e_6871e7e06ba8832a804a932d459f68c6